### PR TITLE
fix: 修復刪除任務後重新整理會還原的問題

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,10 +11,10 @@ class TodoApp {
     init() {
         // 從 LocalStorage 載入資料
         this.loadTodos();
-        
+
         // 綁定事件
         this.bindEvents();
-        
+
         // 初始渲染
         this.render();
     }
@@ -35,7 +35,7 @@ class TodoApp {
     addTodo() {
         const input = document.getElementById('todoInput');
         const text = input.value.trim();
-        
+
         if (!text) return;
 
         const todo = {
@@ -48,7 +48,7 @@ class TodoApp {
         this.todos.push(todo);
         this.saveTodos();
         this.render();
-        
+
         input.value = '';
     }
 
@@ -63,19 +63,18 @@ class TodoApp {
 
     deleteTodo(id) {
         this.todos = this.todos.filter(t => t.id !== id);
-        // BUG: 忘記呼叫 saveTodos()，導致刪除後重新整理會還原
-        // this.saveTodos();
+        this.saveTodos(); // 修正：刪除後立即儲存
         this.render();
     }
 
     setFilter(filter) {
         this.currentFilter = filter;
-        
+
         // 更新按鈕狀態
         document.querySelectorAll('.filter-btn').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.filter === filter);
         });
-        
+
         this.render();
     }
 
@@ -103,7 +102,7 @@ class TodoApp {
     render() {
         const todoList = document.getElementById('todoList');
         const filteredTodos = this.getFilteredTodos();
-        
+
         if (filteredTodos.length === 0) {
             todoList.innerHTML = '<li class="empty-state">沒有任務</li>';
         } else {
@@ -118,7 +117,7 @@ class TodoApp {
                 </li>
             `).join('');
         }
-        
+
         this.updateStats();
     }
 


### PR DESCRIPTION
##  解決的問題\nFixes #2\n\n修復刪除任務後，重新整理頁面被刪除的任務又出現的 bug。\n\n## 🔧 實作內容\n- deleteTodo() 補上 this.saveTodos()，確保刪除後立即儲存到 LocalStorage\n- 維持原有 render() 呼叫，確保 UI 同步更新\n\n##  測試步驟\n1. 開啟 \n2. 新增幾個任務\n3. 刪除其中一個任務\n4. 重新整理頁面\n5. 預期被刪除的任務不會再出現\n\n## 🤔 需要特別注意\n- 請確認刪除、切換 filter、重新整理等操作皆正常